### PR TITLE
fix: always use startService

### DIFF
--- a/android/src/main/java/app/notifee/core/ForegroundService.java
+++ b/android/src/main/java/app/notifee/core/ForegroundService.java
@@ -17,6 +17,7 @@ package app.notifee.core;
  *
  */
 
+import android.util.Log;
 import android.app.Notification;
 import android.app.Service;
 import android.content.Intent;
@@ -45,10 +46,14 @@ public class ForegroundService extends Service {
     intent.putExtra("notification", notification);
     intent.putExtra("notificationBundle", notificationBundle);
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    // TODO pass this config from notificationBundle
+    boolean startServiceWithPromise = false;
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && startServiceWithPromise) {
+      Log.d(TAG, "Using startForegroundService");
       ContextHolder.getApplicationContext().startForegroundService(intent);
     } else {
-      // TODO test this on older device
+      Log.d(TAG, "Using startService");
       ContextHolder.getApplicationContext().startService(intent);
     }
   }


### PR DESCRIPTION
Always use `startService` (https://github.com/invertase/notifee/issues/127#issuecomment-1340641061)